### PR TITLE
Add an `--exclusions` option

### DIFF
--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -15,7 +15,7 @@ final class Application extends DefaultApplication
 {
     public const ACTIVE_DIR_OPTION = 'active-dir';
     public const STAGING_DIR_OPTION = 'staging-dir';
-	public const INCLUDE_DIR_OPTION = 'include-dir';
+    public const INCLUDE_DIR_OPTION = 'include-dir';
 
     public const ACTIVE_DIR_DEFAULT = '.';
     public const STAGING_DIR_DEFAULT = '.composer_staging';
@@ -51,14 +51,14 @@ final class Application extends DefaultApplication
                     self::STAGING_DIR_DEFAULT,
                 ),
             );
-	        $inputDefinition->addOption(
-		        new InputOption(
-			        self::INCLUDE_DIR_OPTION,
-			        'i',
-			        InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED,
-			        'If specified only sync the given directories and exclude all others.'
-		        ),
-	        );
+            $inputDefinition->addOption(
+                new InputOption(
+                    self::INCLUDE_DIR_OPTION,
+                    'i',
+                    InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED,
+                    'If specified only sync the given directories and exclude all others.',
+                ),
+            );
         } catch (InvalidArgumentException $e) {
             throw new LogicException($e->getMessage(), $e->getCode(), $e);
         }

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -15,6 +15,7 @@ final class Application extends DefaultApplication
 {
     public const ACTIVE_DIR_OPTION = 'active-dir';
     public const STAGING_DIR_OPTION = 'staging-dir';
+	public const INCLUDE_DIR_OPTION = 'include-dir';
 
     public const ACTIVE_DIR_DEFAULT = '.';
     public const STAGING_DIR_DEFAULT = '.composer_staging';
@@ -50,6 +51,14 @@ final class Application extends DefaultApplication
                     self::STAGING_DIR_DEFAULT,
                 ),
             );
+	        $inputDefinition->addOption(
+		        new InputOption(
+			        self::INCLUDE_DIR_OPTION,
+			        'i',
+			        InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED,
+			        'If specified only sync the given directories and exclude all others.'
+		        ),
+	        );
         } catch (InvalidArgumentException $e) {
             throw new LogicException($e->getMessage(), $e->getCode(), $e);
         }

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -16,6 +16,7 @@ final class Application extends DefaultApplication
     public const ACTIVE_DIR_OPTION = 'active-dir';
     public const STAGING_DIR_OPTION = 'staging-dir';
     public const INCLUDE_DIR_OPTION = 'include-dir';
+    public const EXCLUDE_DIR_OPTION = 'exclude-dir';
 
     public const ACTIVE_DIR_DEFAULT = '.';
     public const STAGING_DIR_DEFAULT = '.composer_staging';
@@ -57,6 +58,14 @@ final class Application extends DefaultApplication
                     'i',
                     InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED,
                     'If specified only sync the given directories and exclude all others.',
+                ),
+            );
+            $inputDefinition->addOption(
+                new InputOption(
+                    self::EXCLUDE_DIR_OPTION,
+                    'e',
+                    InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED,
+                    'Specify directories to exclude from syncing.',
                 ),
             );
         } catch (InvalidArgumentException $e) {

--- a/src/Console/Command/AbstractCommand.php
+++ b/src/Console/Command/AbstractCommand.php
@@ -131,7 +131,7 @@ abstract class AbstractCommand extends Command
 
         if (! empty($includeDirs)) {
             // Filter the list to exclude the entries not in the included array
-            $exclusions = $this->getExcludedPaths($this->activeDir->absolute(), $includeDirs);
+            $exclusions = $this->getExcludedPaths($this->getCurrentDir()->absolute(), $includeDirs);
         }
 
         $excludeDirs = $input->getOption(Application::EXCLUDE_DIR_OPTION);
@@ -142,6 +142,11 @@ abstract class AbstractCommand extends Command
     protected function getActiveDir(): PathInterface
     {
         return $this->activeDir;
+    }
+
+    protected function getCurrentDir(): PathInterface
+    {
+        return $this->getActiveDir();
     }
 
     protected function getExclusions(): PathListInterface

--- a/src/Console/Command/AbstractCommand.php
+++ b/src/Console/Command/AbstractCommand.php
@@ -122,15 +122,21 @@ abstract class AbstractCommand extends Command
         assert(is_string($stagingDir));
         $this->stagingDir = $this->pathFactory->create($stagingDir);
 
-        $includeDirs = $input->getOption(Application::INCLUDE_DIR_OPTION);
-
-        if (!$this->pathListFactory || empty($includeDirs)) {
+        if (!$this->pathListFactory) {
             return;
         }
 
-        // Filter the list to exclude the entries not in the included array
-        $exclusions = $this->getExcludedPaths($this->activeDir->absolute(), $includeDirs);
-        $this->exclusions = $this->pathListFactory->create(...$exclusions);
+        $exclusions = [];
+        $includeDirs = $input->getOption(Application::INCLUDE_DIR_OPTION);
+
+        if (! empty($includeDirs)) {
+            // Filter the list to exclude the entries not in the included array
+            $exclusions = $this->getExcludedPaths($this->activeDir->absolute(), $includeDirs);
+        }
+
+        $excludeDirs = $input->getOption(Application::EXCLUDE_DIR_OPTION);
+
+        $this->exclusions = $this->pathListFactory->create(...$exclusions, ...$excludeDirs);
     }
 
     protected function getActiveDir(): PathInterface

--- a/src/Console/Command/AbstractCommand.php
+++ b/src/Console/Command/AbstractCommand.php
@@ -131,7 +131,7 @@ abstract class AbstractCommand extends Command
 
         if (! empty($includeDirs)) {
             // Filter the list to exclude the entries not in the included array
-            $exclusions = $this->getExcludedPaths($this->getCurrentDir()->absolute(), $includeDirs);
+            $exclusions = $this->getExcludedPaths($this->activeDir->absolute(), $includeDirs);
         }
 
         $excludeDirs = $input->getOption(Application::EXCLUDE_DIR_OPTION);
@@ -142,11 +142,6 @@ abstract class AbstractCommand extends Command
     protected function getActiveDir(): PathInterface
     {
         return $this->activeDir;
-    }
-
-    protected function getCurrentDir(): PathInterface
-    {
-        return $this->getActiveDir();
     }
 
     protected function getExclusions(): PathListInterface

--- a/src/Console/Command/BeginCommand.php
+++ b/src/Console/Command/BeginCommand.php
@@ -15,8 +15,11 @@ final class BeginCommand extends AbstractCommand
 {
     private const NAME = 'begin';
 
-    public function __construct(private readonly BeginnerInterface $beginner, PathFactoryInterface $pathFactory, PathListFactoryInterface $pathListFactory)
-    {
+    public function __construct(
+        private readonly BeginnerInterface $beginner,
+        PathFactoryInterface $pathFactory,
+        PathListFactoryInterface $pathListFactory,
+    ) {
         parent::__construct(self::NAME, $pathFactory, $pathListFactory);
     }
 
@@ -32,11 +35,10 @@ final class BeginCommand extends AbstractCommand
         //     API; be sure to catch the appropriate exceptions.
         // ---------------------------------------------------------------------
         try {
-
             $this->beginner->begin(
                 $this->getActiveDir(),
                 $this->getStagingDir(),
-	            $this->getExclusions(),
+                $this->getExclusions(),
                 new ProcessOutputCallback($input, $output),
             );
 

--- a/src/Console/Command/BeginCommand.php
+++ b/src/Console/Command/BeginCommand.php
@@ -5,6 +5,7 @@ namespace PhpTuf\ComposerStagerConsole\Console\Command;
 use PhpTuf\ComposerStager\API\Core\BeginnerInterface;
 use PhpTuf\ComposerStager\API\Exception\ExceptionInterface;
 use PhpTuf\ComposerStager\API\Path\Factory\PathFactoryInterface;
+use PhpTuf\ComposerStager\API\Path\Factory\PathListFactoryInterface;
 use PhpTuf\ComposerStagerConsole\Console\Output\ProcessOutputCallback;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -14,9 +15,9 @@ final class BeginCommand extends AbstractCommand
 {
     private const NAME = 'begin';
 
-    public function __construct(private readonly BeginnerInterface $beginner, PathFactoryInterface $pathFactory)
+    public function __construct(private readonly BeginnerInterface $beginner, PathFactoryInterface $pathFactory, PathListFactoryInterface $pathListFactory)
     {
-        parent::__construct(self::NAME, $pathFactory);
+        parent::__construct(self::NAME, $pathFactory, $pathListFactory);
     }
 
     protected function configure(): void
@@ -31,10 +32,11 @@ final class BeginCommand extends AbstractCommand
         //     API; be sure to catch the appropriate exceptions.
         // ---------------------------------------------------------------------
         try {
+
             $this->beginner->begin(
                 $this->getActiveDir(),
                 $this->getStagingDir(),
-                null,
+	            $this->getExclusions(),
                 new ProcessOutputCallback($input, $output),
             );
 

--- a/src/Console/Command/CommitCommand.php
+++ b/src/Console/Command/CommitCommand.php
@@ -6,6 +6,7 @@ use PhpTuf\ComposerStager\API\Core\CommitterInterface;
 use PhpTuf\ComposerStager\API\Exception\ExceptionInterface;
 use PhpTuf\ComposerStager\API\Path\Factory\PathFactoryInterface;
 use PhpTuf\ComposerStager\API\Path\Factory\PathListFactoryInterface;
+use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStagerConsole\Console\Output\ProcessOutputCallback;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Exception\LogicException;
@@ -33,6 +34,11 @@ final class CommitCommand extends AbstractCommand
         $this->setDescription(
             'Makes the staged changes live by syncing the active directory with the staging directory',
         );
+    }
+
+    protected function getCurrentDir(): PathInterface
+    {
+        return $this->getStagingDir();
     }
 
     /** @throws \Symfony\Component\Console\Exception\LogicException */

--- a/src/Console/Command/CommitCommand.php
+++ b/src/Console/Command/CommitCommand.php
@@ -5,6 +5,7 @@ namespace PhpTuf\ComposerStagerConsole\Console\Command;
 use PhpTuf\ComposerStager\API\Core\CommitterInterface;
 use PhpTuf\ComposerStager\API\Exception\ExceptionInterface;
 use PhpTuf\ComposerStager\API\Path\Factory\PathFactoryInterface;
+use PhpTuf\ComposerStager\API\Path\Factory\PathListFactoryInterface;
 use PhpTuf\ComposerStagerConsole\Console\Output\ProcessOutputCallback;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Exception\LogicException;
@@ -19,9 +20,9 @@ final class CommitCommand extends AbstractCommand
 {
     private const NAME = 'commit';
 
-    public function __construct(private readonly CommitterInterface $committer, PathFactoryInterface $pathFactory)
+    public function __construct(private readonly CommitterInterface $committer, PathFactoryInterface $pathFactory, PathListFactoryInterface $pathListFactory)
     {
-        parent::__construct(self::NAME, $pathFactory);
+        parent::__construct(self::NAME, $pathFactory, $pathListFactory);
     }
 
     protected function configure(): void
@@ -46,7 +47,7 @@ final class CommitCommand extends AbstractCommand
             $this->committer->commit(
                 $this->getStagingDir(),
                 $this->getActiveDir(),
-                null,
+	            $this->getExclusions(),
                 new ProcessOutputCallback($input, $output),
             );
 

--- a/src/Console/Command/CommitCommand.php
+++ b/src/Console/Command/CommitCommand.php
@@ -6,7 +6,6 @@ use PhpTuf\ComposerStager\API\Core\CommitterInterface;
 use PhpTuf\ComposerStager\API\Exception\ExceptionInterface;
 use PhpTuf\ComposerStager\API\Path\Factory\PathFactoryInterface;
 use PhpTuf\ComposerStager\API\Path\Factory\PathListFactoryInterface;
-use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStagerConsole\Console\Output\ProcessOutputCallback;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Exception\LogicException;
@@ -34,11 +33,6 @@ final class CommitCommand extends AbstractCommand
         $this->setDescription(
             'Makes the staged changes live by syncing the active directory with the staging directory',
         );
-    }
-
-    protected function getCurrentDir(): PathInterface
-    {
-        return $this->getStagingDir();
     }
 
     /** @throws \Symfony\Component\Console\Exception\LogicException */

--- a/src/Console/Command/CommitCommand.php
+++ b/src/Console/Command/CommitCommand.php
@@ -20,8 +20,11 @@ final class CommitCommand extends AbstractCommand
 {
     private const NAME = 'commit';
 
-    public function __construct(private readonly CommitterInterface $committer, PathFactoryInterface $pathFactory, PathListFactoryInterface $pathListFactory)
-    {
+    public function __construct(
+        private readonly CommitterInterface $committer,
+        PathFactoryInterface $pathFactory,
+        PathListFactoryInterface $pathListFactory,
+    ) {
         parent::__construct(self::NAME, $pathFactory, $pathListFactory);
     }
 
@@ -47,7 +50,7 @@ final class CommitCommand extends AbstractCommand
             $this->committer->commit(
                 $this->getStagingDir(),
                 $this->getActiveDir(),
-	            $this->getExclusions(),
+                $this->getExclusions(),
                 new ProcessOutputCallback($input, $output),
             );
 


### PR DESCRIPTION
This adds the option `--include-dir` which can be specified multiple times. If given, only the given directories are synced and all other are excluded.
We use this for our WordPress project where the `composer.json` file is in the root of the project and we only want to sync the `wp`, `vendors`,`wp-content/plugins`,`wp-content/mu-plugins` and `wp-content/themes` directories. Specifying all other files and directories to exclude would be very fragile and cumbersome.